### PR TITLE
fix: check for auction registrations

### DIFF
--- a/index.js
+++ b/index.js
@@ -370,7 +370,7 @@ async function main(provider, registrations, auctionRegistrations, registrations
   if (registeredDomainsAuction)
     console.log(`Registered domains with the auction registrar(legacy): ${registeredDomainsAuction}`);
 
-  if (!registeredDomainsAuction && auctionRegistrar)
+  if (!registeredDomainsAuction && auctionRegistrations && auctionRegistrations.length)
     console.log(`${chalk.yellowBright('An error occurred registering domains with the auction.')} Ensure you can execute evm_increaseTime and evm_mine`);
 
   if (registeredDomainsRSKRegistrar)


### PR DESCRIPTION
* Fixes the validation to check if actual Auction registrations were requested.  The previous code was displaying the error message even if no domains were passed for the auctions parameter.

This was happening because the check should be done against `auctionRegistrations` and not `auctionRegistrar` which is always instantiated.